### PR TITLE
feat: Add Docker build and deployment for Joplin Web App

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -1,45 +1,90 @@
-name: Build and deploy to pages
-
+name: Build and deploy to pages and container registry
 on:
   workflow_dispatch:
 
-# GITHUB_TOKEN permssions for deploying to pages
 permissions:
   contents: read
   pages: write
   id-token: write
+  packages: write # Needed for pushing to ghcr.io
 
 concurrency:
   group: "pages"
   cancel-in-progress: true
 
 jobs:
-  deploy:
+  build_and_deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      # Step 1: Checkout *your* repository (contains Dockerfile and this workflow)
+      - name: Checkout Workflow Repo
+        uses: actions/checkout@v4
+        # No 'repository' needed, defaults to the current repo
+
+      # Step 2: Checkout Joplin into a subdirectory
+      - name: Checkout Joplin Source
         uses: actions/checkout@v4
         with:
           repository: 'laurent22/joplin'
           ref: dev
+          path: joplin # Checkout into a 'joplin' subdirectory
+
       - name: Prepare yarn
         run: corepack enable
-      - name: Install dependencies
+
+      - name: Install Joplin dependencies
+        working-directory: ./joplin # Specify working directory
         run: yarn install
-      - name: Build pages
-        run: cd packages/app-mobile/ && yarn web
-      - name: Copy pages artifact
+
+      - name: Build Joplin pages
+        working-directory: ./joplin/packages/app-mobile # Specify working directory
+        run: yarn web
+
+      - name: Create pages directory and Copy Joplin artifact
         run: |
-          cp -r packages/app-mobile/web/dist/ pages/
+          mkdir -p pages/ # Ensure pages directory exists at the root
+          cp -r joplin/packages/app-mobile/web/dist/* pages/ # Copy contents into pages/
+
+      # --- GitHub Pages Deployment ---
       - name: Setup Pages
         uses: actions/configure-pages@v5
-      - name: Upload artifact
+
+      - name: Upload artifact for Pages
         uses: actions/upload-pages-artifact@v3
         with:
-          path: 'pages/'
+          path: 'pages/' # Upload the created pages directory
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+      # --- Docker Container Deployment ---
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set image tag
+        id: vars
+        run: echo "tag=$(date +'%Y%m%d-%H%M%S')" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        # No 'with: driver: docker-container' needed unless specific features required
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: . # Use the root of the workspace as context
+          # Dockerfile should be found at ./Dockerfile
+          # COPY ./pages/ will work because pages/ exists at the root
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ steps.vars.outputs.tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,3 @@
 FROM nginx:alpine
 COPY ./pages/ /usr/share/nginx/html
+COPY coop-coep.conf /etc/nginx/conf.d/coop-coep.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY ./pages/ /usr/share/nginx/html

--- a/README.md
+++ b/README.md
@@ -4,6 +4,90 @@ This repository deploys the Joplin web client to https://app.joplincloud.com/ wi
 
 The web app source code can be found in [the main Joplin repository](https://github.com/laurent22/joplin).
 
+## Running Joplin WebApp with Docker
+
+**Prerequisites:**
+
+* Docker installed and running.
+* A running instance of Joplin Server, accessible via a URL (e.g., `https://joplin-server.yourdomain.com`).
+
+**1. Pull the Docker Image:**
+
+Fetch the latest official Joplin WebApp image:
+
+```bash
+docker pull ghcr.io/joplin/web-app:latest
+```
+
+**2. Run the Docker Container:**
+
+Run the container, mapping a host port (e.g., `8088`) to the container's port `80`, and giving it a recognizable name. Running in detached mode (`-d`) is recommended for background operation.
+
+```bash
+docker run -d --name joplin-webapp -p 8088:80 ghcr.io/joplin/web-app:latest
+```
+
+* You will initially access the WebApp via `http://<your-docker-host-ip>:8088`.
+* **Note:** The WebApp container itself doesn't handle HTTPS. This is typically managed by a reverse proxy (see Step 3).
+
+**3. Configure HTTPS and Reverse Proxy:**
+
+Both the Joplin WebApp and Joplin Server **must** be served over HTTPS for secure communication and browser compatibility. A reverse proxy (like Nginx, Apache, Caddy, or Traefik) is the standard way to achieve this.
+
+* Set up a reverse proxy for the Joplin WebApp container (listening on port `8088` locally) to serve it under your desired HTTPS domain (e.g., `https://joplin-webapp.yourdomain.com`).
+* You can obtain free SSL/TLS certificates from [Let's Encrypt](https://letsencrypt.org/).
+
+**4. Configure CORS Headers on Joplin Server:**
+
+Because the WebApp (e.g., `https://joplin-webapp.yourdomain.com`) and the Joplin Server (e.g., `https://joplin-server.yourdomain.com`) are running on different origins (domains/ports), you must configure Cross-Origin Resource Sharing (CORS) headers on the **Joplin Server's reverse proxy**. This tells the browser that it's safe for the WebApp to make requests to the Server API.
+
+**Nginx Example:**
+
+Add the following within the `server` or `location` block handling your Joplin Server traffic in your Nginx configuration.
+
+```nginx
+# Set this variable to the exact origin (scheme + domain + port)
+# from which your Joplin WebApp is served.
+set $my_origin 'https://joplin-webapp.yourdomain.com; # <-- CHANGE THIS
+if ($request_method = 'OPTIONS') {
+    add_header 'Access-Control-Allow-Origin'  $my_origin always; 
+    add_header 'Access-Control-Allow-Credentials' 'true' always; 
+    add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH, OPTIONS' always;
+    add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type, Accept, Origin, X-Requested-With, X-Api-Key, X-Api-Auth, DNT, Cache-Control, If-Modified-Since, If-None-Match, Range, x-api-min-version' always; 
+    add_header 'Access-Control-Max-Age' 86400 always;
+    add_header 'Content-Length' 0;
+    return 204;
+}
+
+proxy_hide_header Access-Control-Allow-Origin;
+proxy_hide_header Access-Control-Allow-Credentials;
+add_header Access-Control-Allow-Origin  $my_origin  always;
+add_header Access-Control-Allow-Credentials 'true' always;
+```
+
+* **Crucial:** Replace `https://joplin-webapp.yourdomain.com` with the *actual URL* you use to access the Joplin WebApp in your browser.
+* **Apache/Other Proxies:** Equivalent directives exist for other servers (e.g., `Header set Access-Control-Allow-Origin "..."` in Apache). Consult your reverse proxy's documentation for CORS configuration.
+
+**5. (Potential) Configure Joplin Server URL in WebApp:**
+
+The WebApp needs to know the URL of your Joplin Server API. This is often configured via environment variables passed to the Docker container. Check the Joplin WebApp's documentation for the specific environment variable name (it might be something like `JOPLIN_API_BASE_URL` or similar).
+
+Example if the variable was `JOPLIN_API_BASE_URL`:
+
+```bash
+docker run -d --name joplin-webapp \
+-p 8088:80 \
+-e JOPLIN_API_BASE_URL='[https://joplin-server.yourdomain.com](https://joplin-server.yourdomain.com)' \
+ghcr.io/joplin/web-app:latest
+```
+
+* Replace `https://joplin-server.yourdomain.com` with the public HTTPS URL of your Joplin Server.
+* **Note:** Consult the official Joplin WebApp documentation or image source for the correct environment variable name if needed.
+
+**6. Access the Application:**
+
+Once configured, you should be able to access the Joplin WebApp via the HTTPS URL you set up in your reverse proxy (e.g., `https://joplin-webapp.yourdomain.com`). It will then communicate with your Joplin Server in the background.
+
 
 ## FAQ
 

--- a/coop-coep.conf
+++ b/coop-coep.conf
@@ -1,0 +1,3 @@
+# Add required headers for crossOriginIsolated=true
+add_header 'Cross-Origin-Opener-Policy' 'same-origin' always;
+add_header 'Cross-Origin-Embedder-Policy' 'require-corp' always;


### PR DESCRIPTION
This PR introduces the capability to build the Joplin web client and deploy it both as a static site via GitHub Pages and as a Docker container image to the GitHub Container Registry (GHCR).

**Key Changes:**

* **GitHub Actions Workflow (`.github/workflows/deploy-github-pages.yml`):**
    * Fetch the Joplin source code from `laurent22/joplin`.
    * Builds the Joplin web app (`packages/app-mobile/yarn web`).
    * Deploys the static build artifacts to GitHub Pages.
    * Builds a Docker image using the new `Dockerfile`.
    * Pushes the Docker image to `ghcr.io/${{ github.repository }}` with `latest` and date-based tags, supporting `linux/amd64` and `linux/arm64`.
    * Added `packages: write` permissions for GHCR push.
* **`Dockerfile`:**
    * New file defining a multi-stage build process.
    * Uses `nginx:alpine` as the final stage.
    * Copies the built static web app files (`./pages/`) into the Nginx web root.
    * Copies the `coop-coep.conf` Nginx configuration file.
* **`coop-coep.conf`:**
    * New Nginx configuration snippet.
    * Adds `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp` headers. These are necessary to enable `crossOriginIsolated=true` context,  required for feature `SharedArrayBuffer`.
* **`README.md`:**
    * Updated with a new section: "Running Joplin WebApp with Docker".
    * Provides detailed instructions on pulling the image (Note: Users should pull from `ghcr.io/${{ github.repository }}:latest`), running the container, and crucial configuration steps.
    * Emphasizes the requirement for HTTPS via a reverse proxy for *both* the web app and the Joplin Server.
    * Includes an example Nginx configuration for setting required CORS headers on the **Joplin Server's** reverse proxy, which is essential for communication between the web app and the server API.
    * Mentions the potential need to configure the Joplin Server API URL via environment variables in the Docker container.

**Motivation:**

The primary driver for this change is to enhance user privacy and control. By providing an official, easy-to-use Docker container for the Joplin web app, users are empowered to self-host the *entire* Joplin experience – both the server and the web client – within their own trusted website. This significantly reduces reliance on external services for accessing notes via a web browser and ensures that user data primarily transits systems they manage directly, offering a more private alternative to using centrally hosted web applications.

**Usage:**

Refer to the updated `README.md` for detailed instructions on pulling and running the Docker image, including necessary reverse proxy and CORS configuration on the Joplin Server side. 

**Testing:**

For testing purposes, I've deployed the web-app here https://github.com/adamoutler/web-app/pkgs/container/web-app and it can be tested using 
```
docker pull ghcr.io/adamoutler/web-app:latest
docker run -it -p8088:80 ghcr.io/adamoutler/web-app:latest
```